### PR TITLE
Add Claude session hooks and MCP server configuration

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+DOTNET_INSTALL_DIR="${HOME}/.dotnet"
+export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
+export PATH="${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:${PATH}"
+
+# ── 1. Install .NET SDK if missing ─────────────────────────────────────────
+if ! command -v dotnet &>/dev/null || [ ! -f "${DOTNET_INSTALL_DIR}/dotnet" ]; then
+  echo "Installing .NET SDK..."
+  curl -fsSL https://dot.net/v1/dotnet-install.sh \
+    | bash -s -- --channel 9.0 --install-dir "${DOTNET_INSTALL_DIR}"
+  echo ".NET SDK installed."
+else
+  echo ".NET SDK already present: $(dotnet --version)"
+fi
+
+# Persist dotnet on PATH for the session
+echo "export DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "${CLAUDE_ENV_FILE}"
+echo "export PATH=${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:\${PATH}" >> "${CLAUDE_ENV_FILE}"
+
+# ── 2. Restore BannerlordSearch.Source v1.3.1 into NuGet global cache ──────
+NUGET_CACHE="${HOME}/.nuget/packages"
+SOURCE_PKG_DIR="${NUGET_CACHE}/bannerlordSearch.source/1.3.1"
+
+if [ ! -d "${SOURCE_PKG_DIR}" ]; then
+  echo "Restoring BannerlordSearch.Source v1.3.1..."
+  TEMP_DIR=$(mktemp -d)
+  trap "rm -rf ${TEMP_DIR}" EXIT
+
+  cat > "${TEMP_DIR}/tmp.csproj" << 'CSPROJ'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BannerlordSearch.Source" Version="1.3.1" />
+  </ItemGroup>
+</Project>
+CSPROJ
+
+  dotnet restore "${TEMP_DIR}/tmp.csproj" 2>&1
+  echo "BannerlordSearch.Source restored."
+else
+  echo "BannerlordSearch.Source already in NuGet cache."
+fi
+
+# ── 3. Locate contentFiles and export BANNERLORD_SOURCE_PATH ───────────────
+SOURCE_CONTENTFILES=$(find "${NUGET_CACHE}" \
+  -ipath "*bannerlordSearch.source/1.3.1/contentfiles*" \
+  -type d | head -1)
+
+if [ -z "${SOURCE_CONTENTFILES}" ]; then
+  # Broader fallback search
+  SOURCE_CONTENTFILES=$(find "${NUGET_CACHE}" \
+    -ipath "*bannerlord*source*1.3.1*contentfiles*" \
+    -type d | head -1)
+fi
+
+if [ -n "${SOURCE_CONTENTFILES}" ]; then
+  echo "BANNERLORD_SOURCE_PATH=${SOURCE_CONTENTFILES}"
+  echo "export BANNERLORD_SOURCE_PATH=${SOURCE_CONTENTFILES}" >> "${CLAUDE_ENV_FILE}"
+  export BANNERLORD_SOURCE_PATH="${SOURCE_CONTENTFILES}"
+else
+  echo "WARNING: Could not locate BannerlordSearch.Source contentFiles in NuGet cache."
+fi
+
+# ── 4. Install BannerlordSearch.Mcp.Server global tool (idempotent) ────────
+if ! dotnet tool list -g 2>/dev/null | grep -qi "BannerlordSearch.Mcp.Server"; then
+  echo "Installing BannerlordSearch.Mcp.Server..."
+  dotnet tool install --global BannerlordSearch.Mcp.Server
+  echo "BannerlordSearch.Mcp.Server installed."
+else
+  echo "BannerlordSearch.Mcp.Server already installed."
+fi
+
+# ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ─────────
+pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
+sleep 1
+
+MCP_LOG="/tmp/bannerlord-mcp-server.log"
+
+nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
+  --transport streamable-http \
+  --urls "http://localhost:5000" \
+  > "${MCP_LOG}" 2>&1 &
+
+MCP_PID=$!
+echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
+
+# Wait for server to become ready (up to 15s)
+for i in $(seq 1 15); do
+  if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
+     curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+    echo "MCP server is ready."
+    break
+  fi
+  sleep 1
+done
+
+echo "Session start hook completed."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -75,27 +75,32 @@ else
 fi
 
 # ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ─────────
-pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
-sleep 1
-
 MCP_LOG="/tmp/bannerlord-mcp-server.log"
 
-nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
-  --transport streamable-http \
-  --urls "http://localhost:5000" \
-  > "${MCP_LOG}" 2>&1 &
-
-MCP_PID=$!
-echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
-
-# Wait for server to become ready (up to 15s)
-for i in $(seq 1 15); do
-  if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
-     curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
-    echo "MCP server is ready."
-    break
-  fi
+if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
+   curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+  echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
+else
+  pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
   sleep 1
-done
+
+  nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
+    --transport streamable-http \
+    --urls "http://localhost:5000" \
+    > "${MCP_LOG}" 2>&1 &
+
+  MCP_PID=$!
+  echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
+
+  # Wait for server to become ready (up to 15s)
+  for i in $(seq 1 15); do
+    if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
+       curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+      echo "MCP server is ready."
+      break
+    fi
+    sleep 1
+  done
+fi
 
 echo "Session start hook completed."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -93,7 +93,7 @@ else
   echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
 
   # Wait for server to become ready (up to 15s)
-  for i in $(seq 1 15); do
+  for i in $(seq 1 30); do
     if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
        curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
       echo "MCP server is ready."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 DOTNET_INSTALL_DIR="${HOME}/.dotnet"
 export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
 export PATH="${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:${PATH}"
 
 # ── 1. Install .NET SDK if missing ─────────────────────────────────────────
-if ! command -v dotnet &>/dev/null || [ ! -f "${DOTNET_INSTALL_DIR}/dotnet" ]; then
+if ! command -v dotnet >/dev/null 2>&1 || [ ! -f "${DOTNET_INSTALL_DIR}/dotnet" ]; then
   echo "Installing .NET SDK..."
   curl -fsSL https://dot.net/v1/dotnet-install.sh \
-    | bash -s -- --channel 10.0 --install-dir "${DOTNET_INSTALL_DIR}"
+    | sh -s -- --channel 10.0 --install-dir "${DOTNET_INSTALL_DIR}"
   echo ".NET SDK installed."
 else
   echo ".NET SDK already present: $(dotnet --version)"
@@ -92,14 +92,16 @@ else
   MCP_PID=$!
   echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
 
-  # Wait for server to become ready (up to 15s)
-  for i in $(seq 1 30); do
+  # Wait for server to become ready (up to 30s)
+  i=1
+  while [ "$i" -le 30 ]; do
     if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
        curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
       echo "MCP server is ready."
       break
     fi
     sleep 1
+    i=$((i + 1))
   done
 fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in remote (web) sessions
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
-fi
-
 DOTNET_INSTALL_DIR="${HOME}/.dotnet"
 export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
 export PATH="${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:${PATH}"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,7 +9,7 @@ export PATH="${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:${PATH}"
 if ! command -v dotnet &>/dev/null || [ ! -f "${DOTNET_INSTALL_DIR}/dotnet" ]; then
   echo "Installing .NET SDK..."
   curl -fsSL https://dot.net/v1/dotnet-install.sh \
-    | bash -s -- --channel 9.0 --install-dir "${DOTNET_INSTALL_DIR}"
+    | bash -s -- --channel 10.0 --install-dir "${DOTNET_INSTALL_DIR}"
   echo ".NET SDK installed."
 else
   echo ".NET SDK already present: $(dotnet --version)"
@@ -31,7 +31,7 @@ if [ ! -d "${SOURCE_PKG_DIR}" ]; then
   cat > "${TEMP_DIR}/tmp.csproj" << 'CSPROJ'
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BannerlordSearch.Source" Version="1.3.1" />

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,30 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,15 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' &&
+      (github.event.sender.login == github.repository_owner ||
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association || github.event.issue.author_association || github.event.review.author_association)) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "bannerlord-search": {
       "type": "streamable-http",
-      "url": "http://localhost:5000/mcp"
+      "url": "http://localhost:5000"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "bannerlord-search": {
+      "type": "streamable-http",
+      "url": "http://localhost:5000/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Claude IDE integration configuration to automatically set up the .NET environment and BannerlordSearch MCP server on session start.

## Key Changes
- **Session start hook** (`.claude/hooks/session-start.sh`): Automated setup script that:
  - Installs .NET SDK 10.0 if not present
  - Restores BannerlordSearch.Source v1.3.1 NuGet package
  - Locates and exports the source contentFiles path
  - Installs BannerlordSearch.Mcp.Server as a global tool
  - Starts the MCP server on `http://localhost:5000` with streamable HTTP transport
  - Waits up to 15 seconds for server readiness with health checks

- **Claude settings** (`.claude/settings.json`): Registers the session start hook to run automatically when Claude IDE starts

- **MCP configuration** (`.mcp.json`): Configures the BannerlordSearch MCP server endpoint for Claude IDE integration

## Implementation Details
- The setup script is idempotent—it checks for existing installations and running services before taking action
- Environment variables (`DOTNET_ROOT`, `PATH`, `BANNERLORD_SOURCE_PATH`) are persisted via `CLAUDE_ENV_FILE` for the session
- The MCP server is started with `nohup` in the background and logs to `/tmp/bannerlord-mcp-server.log`
- Graceful cleanup: existing MCP server processes are killed before starting a new one
- Health checks use curl to verify server availability before proceeding

https://claude.ai/code/session_015yvK4RTfUKkCGCvwUASMkf