### PR TITLE
Add checkout step to Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,10 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
Added an explicit repository checkout step to the Claude Code workflow before running the Claude Code action.

## Key Changes
- Added `actions/checkout@v4` step with shallow clone configuration (`fetch-depth: 1`) to the workflow
- This ensures the repository is properly checked out before the Claude Code action executes

## Implementation Details
The checkout step is configured with `fetch-depth: 1` to perform a shallow clone, which optimizes workflow performance by only fetching the latest commit rather than the entire repository history. This is placed as the first step in the job, ensuring the codebase is available for subsequent actions.