### PR TITLE
Fix .NET SDK installation script shell invocation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,7 +9,7 @@ export PATH="${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:${PATH}"
 if ! command -v dotnet >/dev/null 2>&1 || [ ! -f "${DOTNET_INSTALL_DIR}/dotnet" ]; then
   echo "Installing .NET SDK..."
   curl -fsSL https://dot.net/v1/dotnet-install.sh \
-    | sh -s -- --channel 10.0 --install-dir "${DOTNET_INSTALL_DIR}"
+    | bash -s -- --channel 10.0 --install-dir "${DOTNET_INSTALL_DIR}"
   echo ".NET SDK installed."
 else
   echo ".NET SDK already present: $(dotnet --version)"


### PR DESCRIPTION
## Summary
Updated the .NET SDK installation script to use `bash` instead of `sh` for better compatibility and reliability.

## Changes
- Changed the shell invocation from `sh` to `bash` when executing the dotnet-install.sh script in the session startup hook

## Details
The dotnet-install.sh script from Microsoft is designed to work with bash and may rely on bash-specific features or syntax. Using `bash` explicitly ensures the script runs in the correct shell environment, improving compatibility and reducing the risk of shell-specific issues that could occur when `sh` points to a different shell implementation on some systems.

https://claude.ai/code/session_014hEmhPARiMHYzLSY4XQhRY