### PR TITLE
Improve session-start.sh robustness and Claude Code integration

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -15,9 +15,11 @@ else
   echo ".NET SDK already present: $(dotnet --version)"
 fi
 
-# Persist dotnet on PATH for the session
-echo "export DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "${CLAUDE_ENV_FILE}"
-echo "export PATH=${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:\${PATH}" >> "${CLAUDE_ENV_FILE}"
+# Persist dotnet on PATH for the session (only when running inside Claude Code)
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export DOTNET_ROOT=${DOTNET_INSTALL_DIR}" >> "${CLAUDE_ENV_FILE}"
+  echo "export PATH=${DOTNET_INSTALL_DIR}:${DOTNET_INSTALL_DIR}/tools:\${PATH}" >> "${CLAUDE_ENV_FILE}"
+fi
 
 # ── 2. Restore BannerlordSearch.Source v1.3.1 into NuGet global cache ──────
 NUGET_CACHE="${HOME}/.nuget/packages"
@@ -59,7 +61,9 @@ fi
 
 if [ -n "${SOURCE_CONTENTFILES}" ]; then
   echo "BANNERLORD_SOURCE_PATH=${SOURCE_CONTENTFILES}"
-  echo "export BANNERLORD_SOURCE_PATH=${SOURCE_CONTENTFILES}" >> "${CLAUDE_ENV_FILE}"
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "export BANNERLORD_SOURCE_PATH=${SOURCE_CONTENTFILES}" >> "${CLAUDE_ENV_FILE}"
+  fi
   export BANNERLORD_SOURCE_PATH="${SOURCE_CONTENTFILES}"
 else
   echo "WARNING: Could not locate BannerlordSearch.Source contentFiles in NuGet cache."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -83,8 +83,7 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   # ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ────────
   MCP_LOG="/tmp/bannerlord-mcp-server.log"
 
-  if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
-     curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+  if curl -sf "http://localhost:5000" >/dev/null 2>&1; then
     echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
   else
     pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
@@ -101,8 +100,7 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     # Wait for server to become ready (up to 30s)
     ready=0
     for i in $(seq 1 30); do
-      if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
-         curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+      if curl -sf "http://localhost:5000" >/dev/null 2>&1; then
         echo "MCP server is ready."
         ready=1
         break

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 DOTNET_INSTALL_DIR="${HOME}/.dotnet"
 export DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
@@ -69,44 +69,52 @@ else
   echo "WARNING: Could not locate BannerlordSearch.Source contentFiles in NuGet cache."
 fi
 
-# ── 4. Install BannerlordSearch.Mcp.Server global tool (idempotent) ────────
-if ! dotnet tool list -g 2>/dev/null | grep -qi "BannerlordSearch.Mcp.Server"; then
-  echo "Installing BannerlordSearch.Mcp.Server..."
-  dotnet tool install --global BannerlordSearch.Mcp.Server
-  echo "BannerlordSearch.Mcp.Server installed."
-else
-  echo "BannerlordSearch.Mcp.Server already installed."
-fi
+# ── 4 & 5. MCP server — only needed inside Claude Code sessions ─────────────
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  # ── 4. Install BannerlordSearch.Mcp.Server global tool (idempotent) ──────
+  if ! dotnet tool list -g 2>/dev/null | grep -qi "BannerlordSearch.Mcp.Server"; then
+    echo "Installing BannerlordSearch.Mcp.Server..."
+    dotnet tool install --global BannerlordSearch.Mcp.Server
+    echo "BannerlordSearch.Mcp.Server installed."
+  else
+    echo "BannerlordSearch.Mcp.Server already installed."
+  fi
 
-# ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ─────────
-MCP_LOG="/tmp/bannerlord-mcp-server.log"
+  # ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ────────
+  MCP_LOG="/tmp/bannerlord-mcp-server.log"
 
-if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
-   curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
-  echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
-else
-  pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
-  sleep 1
-
-  nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
-    --transport streamable-http \
-    --urls "http://localhost:5000" \
-    > "${MCP_LOG}" 2>&1 &
-
-  MCP_PID=$!
-  echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
-
-  # Wait for server to become ready (up to 30s)
-  i=1
-  while [ "$i" -le 30 ]; do
-    if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
-       curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
-      echo "MCP server is ready."
-      break
-    fi
+  if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
+     curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+    echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
+  else
+    pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
     sleep 1
-    i=$((i + 1))
-  done
+
+    nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
+      --transport streamable-http \
+      --urls "http://localhost:5000" \
+      > "${MCP_LOG}" 2>&1 &
+
+    MCP_PID=$!
+    echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
+
+    # Wait for server to become ready (up to 30s)
+    ready=0
+    for i in $(seq 1 30); do
+      if curl -sf "http://localhost:5000" >/dev/null 2>&1 || \
+         curl -sf "http://localhost:5000/mcp" >/dev/null 2>&1; then
+        echo "MCP server is ready."
+        ready=1
+        break
+      fi
+      sleep 1
+    done
+
+    if [ "${ready}" -eq 0 ]; then
+      echo "ERROR: MCP server did not become ready within 30 seconds. Check ${MCP_LOG}." >&2
+      exit 1
+    fi
+  fi
 fi
 
 echo "Session start hook completed."


### PR DESCRIPTION
## Summary
Enhanced the `.claude/hooks/session-start.sh` script to be more robust and better integrated with Claude Code environments. The script now gracefully handles execution outside of Claude Code sessions and includes improved error handling.

## Key Changes
- **Shell improvements**: Changed shebang from `sh` to `bash` and added `pipefail` option to `set -euo pipefail` for better error handling
- **Claude Code environment detection**: Added conditional checks for `CLAUDE_ENV_FILE` variable to prevent errors when the script runs outside Claude Code sessions
  - Environment variable exports now only occur when `CLAUDE_ENV_FILE` is defined
  - MCP server installation and startup are now skipped outside Claude Code
- **Better loop handling**: Replaced manual counter-based while loop with a `for` loop using `seq` for improved readability and POSIX compliance
- **Enhanced error reporting**: Added explicit error message and exit code when MCP server fails to start within the timeout period
- **Code organization**: Consolidated MCP server sections (4 & 5) under a single conditional block with clearer comments

## Implementation Details
- The script now safely handles being sourced in non-Claude environments without attempting to write to undefined `CLAUDE_ENV_FILE`
- MCP server operations are now properly gated behind the Claude Code environment check, preventing unnecessary tool installations in other contexts
- Improved readability with better structured conditionals and comments

https://claude.ai/code/session_01RRDip57u43ozE6wAALiy4S