### PR TITLE
Optimize NuGet caching and find command in CI workflow

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -50,13 +50,13 @@ fi
 # ── 3. Locate contentFiles and export BANNERLORD_SOURCE_PATH ───────────────
 SOURCE_CONTENTFILES=$(find "${NUGET_CACHE}" \
   -ipath "*bannerlordSearch.source/1.3.1/contentfiles*" \
-  -type d | head -1)
+  -type d -print -quit)
 
 if [ -z "${SOURCE_CONTENTFILES}" ]; then
   # Broader fallback search
   SOURCE_CONTENTFILES=$(find "${NUGET_CACHE}" \
     -ipath "*bannerlord*source*1.3.1*contentfiles*" \
-    -type d | head -1)
+    -type d -print -quit)
 fi
 
 if [ -n "${SOURCE_CONTENTFILES}" ]; then

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-bannerlord-source-1.3.1
       - name: Start MCP server
         run: bash .claude/hooks/session-start.sh
       - name: Run Claude Code


### PR DESCRIPTION
## Summary
This PR improves the CI/CD pipeline efficiency by adding NuGet package caching and optimizing the file search logic in the session initialization script.

## Key Changes
- **Add NuGet package caching** to the GitHub Actions workflow to cache `~/.nuget/packages` directory, reducing build times by avoiding redundant package downloads
- **Optimize find command** in `session-start.sh` by replacing `head -1` with `-print -quit` flags, which is more efficient as it terminates the search immediately upon finding the first match instead of collecting all results and then selecting one

## Implementation Details
- The cache key is set to `nuget-bannerlord-source-1.3.1` to match the specific version being used
- The `-print -quit` optimization applies to both the primary search for `bannerlordSearch.source/1.3.1/contentfiles` and the fallback broader search pattern
- These changes maintain the same functional behavior while improving performance and resource utilization

https://claude.ai/code/session_01JF3U6bqKf7S2ZJrkvD1WMg