### PR TITLE
Fix MCP server startup to use global tool command directly

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -90,7 +90,7 @@ if [ -z "${TOOL_CMD}" ]; then
 fi
 echo "Resolved MCP server command: ${TOOL_CMD}"
 
-if curl -sf "http://localhost:5000" >/dev/null 2>&1; then
+if curl -s "http://localhost:5000" >/dev/null 2>&1; then
   echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
 else
   pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
@@ -104,10 +104,12 @@ else
   MCP_PID=$!
   echo "BannerlordSearch.Mcp.Server starting (PID: ${MCP_PID}), log: ${MCP_LOG}"
 
-  # Wait for server to become ready (up to 60s)
+  # Wait for server to become ready (up to 60s).
+  # Use curl without -f so that 4xx responses (e.g. 400 "session id required")
+  # are still treated as "server is up".
   ready=0
   for i in $(seq 1 60); do
-    if curl -sf "http://localhost:5000" >/dev/null 2>&1; then
+    if curl -s "http://localhost:5000" >/dev/null 2>&1; then
       echo "MCP server is ready."
       ready=1
       break

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -81,13 +81,22 @@ fi
 # ── 5. Start MCP server on http://localhost:5000 (streamable HTTP) ────────────
 MCP_LOG="/tmp/bannerlord-mcp-server.log"
 
+# Resolve the actual command name registered by the global tool
+# (dotnet tool run is for local manifest tools only; global tools are called directly)
+TOOL_CMD=$(dotnet tool list -g 2>/dev/null | grep -i "BannerlordSearch.Mcp.Server" | awk '{print $NF}')
+if [ -z "${TOOL_CMD}" ]; then
+  echo "ERROR: BannerlordSearch.Mcp.Server not found in global tools. Install may have failed." >&2
+  exit 1
+fi
+echo "Resolved MCP server command: ${TOOL_CMD}"
+
 if curl -sf "http://localhost:5000" >/dev/null 2>&1; then
   echo "BannerlordSearch.Mcp.Server already running on http://localhost:5000, skipping start."
 else
   pkill -f "BannerlordSearch.Mcp.Server" 2>/dev/null || true
   sleep 1
 
-  nohup dotnet tool run BannerlordSearch.Mcp.Server -- \
+  nohup "${TOOL_CMD}" \
     --transport streamable-http \
     --urls "http://localhost:5000" \
     > "${MCP_LOG}" 2>&1 &


### PR DESCRIPTION
## Summary
Updated the MCP server startup logic to properly resolve and invoke the globally installed `BannerlordSearch.Mcp.Server` tool, and improved server readiness detection to handle HTTP 4xx responses.

## Key Changes
- **Resolve global tool command**: Added logic to query `dotnet tool list -g` and extract the actual command name registered for `BannerlordSearch.Mcp.Server`, rather than assuming `dotnet tool run` works for global tools
- **Direct tool invocation**: Changed from `dotnet tool run BannerlordSearch.Mcp.Server` to invoking the resolved command directly via `"${TOOL_CMD}"`
- **Improved error handling**: Added validation to ensure the tool is installed, with a clear error message if resolution fails
- **Fixed server readiness check**: Removed the `-f` flag from curl commands so that HTTP 4xx responses (e.g., 400 "session id required") are treated as the server being up, rather than failing the health check
- **Enhanced comments**: Clarified the rationale for the curl flag change in the readiness wait loop

## Implementation Details
The key insight is that `dotnet tool run` is only for tools installed via local manifests, while globally installed tools are invoked directly by their registered command name. The tool command is extracted from the `dotnet tool list -g` output and validated before use.

https://claude.ai/code/session_01PFGThECQJEVUpHFUqrV8ZB