### PR TITLE
Change bannerlord-search MCP server type from streamable-http to http

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "bannerlord-search": {
-      "type": "streamable-http",
+      "type": "http",
       "url": "http://localhost:5000"
     }
   }


### PR DESCRIPTION
## Summary
Updated the MCP server configuration for bannerlord-search to use the standard `http` transport type instead of `streamable-http`.

## Changes
- Modified `.mcp.json` to change the `bannerlord-search` server type from `streamable-http` to `http`
- The server URL remains unchanged at `http://localhost:5000`

## Details
This change simplifies the server configuration by using the standard HTTP transport protocol. The `streamable-http` type has been replaced with the basic `http` type, which should be sufficient for the bannerlord-search server's communication needs.

https://claude.ai/code/session_014McKjzL8ZVpYAMK7s9s61m