### PR TITLE
Add MCP server permissions for Bannerlord search functionality

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "enableAllProjectMcpServers": true,
+  "permissions": {
+    "allow": [
+      "mcp__bannerlord-search__get_bannerlord_class_definition",
+      "mcp__bannerlord-search__search_bannerlord_code"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
Added explicit permission configuration for the Bannerlord search MCP (Model Context Protocol) server to enable specific search and class definition lookup capabilities.

## Key Changes
- Added a new `permissions` section to `.claude/settings.json`
- Configured allow-list with two Bannerlord search MCP permissions:
  - `mcp__bannerlord-search__get_bannerlord_class_definition` - enables retrieving class definitions
  - `mcp__bannerlord-search__search_bannerlord_code` - enables searching Bannerlord codebase

## Details
This change implements explicit permission grants for the Bannerlord search MCP server, following a principle of least privilege by only allowing the specific operations needed for Bannerlord development tasks. The permissions are scoped to the bannerlord-search MCP server and allow code search and class definition lookup functionality.

https://claude.ai/code/session_0147WyscmwnavRaD899gAZYa