### PR TITLE
Allow Bash commands for dotnet build and test operations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
   "permissions": {
     "allow": [
       "mcp__bannerlord-search__get_bannerlord_class_definition",
-      "mcp__bannerlord-search__search_bannerlord_code"
+      "mcp__bannerlord-search__search_bannerlord_code",
+      "Bash(dotnet build*)",
+      "Bash(dotnet test*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
Updated Claude settings to permit execution of dotnet build and test commands via Bash, enabling automated compilation and testing workflows.

## Changes
- Added `Bash(dotnet build*)` permission to allow dotnet build command execution
- Added `Bash(dotnet test*)` permission to allow dotnet test command execution

## Details
These permissions enable the Claude MCP integration to execute .NET build and test operations directly, facilitating continuous integration and development workflows within the Bannerlord project context.

https://claude.ai/code/session_017U8YFVHHbk5tBGeWQat8Fk